### PR TITLE
Fix: Update Python script filename in README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ rt-agentic-ai-cert-week2/
 4. **Run the examples:**
    ```bash
    cd code
-   python lesson_1_and_2.py
+   python lesson_1a_and_1b.py
    ```
    **Customize your experiments:** Edit the `prompt_cfg_key` variable in `lesson_1_and_2.py` (near the bottom of the script) to test different prompt configurations (e.g., `summarization_prompt_cfg1` through `summarization_prompt_cfg6`). You can also create new configurations in `config/prompt_config.yaml` to experiment with your own prompt designs.
 


### PR DESCRIPTION
## Summary
Corrected the Python script filename reference in the README documentation.

## Changes
- Updated filename from `lesson_1_and_2.py` to `lesson_1a_and_1b.py` in the execution instructions

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [ ] New feature
- [ ] Breaking change

## Additional Notes
This ensures the documentation accurately reflects the actual script filenames in the codebase.