### PR TITLE
Add API key troubleshooting to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ rt-agentic-ai-cert-week2/
    GROQ_API_KEY=your-groq-key-here
    GOOGLE_API_KEY=your-google-key-here
    ```
+### Troubleshooting API Keys
+
+**Note:** If you encounter persistent API key errors, such as `'api_key' has not been loaded` at startup *or* errors related to `GROQ_API_KEY` during an LLM call, try adding **both** your OpenAI and Groq API keys to your `.env` file.
+
+The script may have an initial check for `OPENAI_API_KEY` while the LLM call itself requires `GROQ_API_KEY`.
+
+Your `.env` file should look like this:
+OPENAI_API_KEY="sk-your-openai-key-here" 
+GROQ_API_KEY="gsk_your-groq-key-here"
 
    **Get your free API key from:**
 


### PR DESCRIPTION

This PR adds a troubleshooting note to the README.md to address a common API key error.

Problem
When running the scripts, a user might encounter a vague error like 'api_key' has not been loaded even if they have correctly set the GROQ_API_KEY in their .env file.

Cause
The application appears to have two separate checks:

An initial load_env() check that looks for OPENAI_API_KEY.

An invoke_llm() call that (correctly) requires GROQ_API_KEY when using Groq-hosted models.

This conflict causes the script to fail at startup if only the GROQ_API_KEY is present.

Solution
This commit updates the README with a new "Troubleshooting API Keys" section, advising users to add both OPENAI_API_KEY and GROQ_API_KEY to their .env file to satisfy both checks.